### PR TITLE
QONV-11

### DIFF
--- a/libqonvince/CMakeLists.txt
+++ b/libqonvince/CMakeLists.txt
@@ -11,7 +11,8 @@ set_target_properties(libqonvince_shared libqonvince_static PROPERTIES
 	CXX_STANDARD 14
 	LIBRARY_OUTPUT_NAME qonvince
 	ARCHIVE_OUTPUT_NAME qonvince
-	SOVERSION 1.0.0
+	VERSION 1.0.0
+	SOVERSION 1
 #	CXX_CLANG_TIDY clang-tidy-5.0
 )
 

--- a/plugins/otpdisplay/integer/eightdigits/CMakeLists.txt
+++ b/plugins/otpdisplay/integer/eightdigits/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(eightdigits_display_plugin PUBLIC ${CMAKE_CURRENT_LIS
 target_link_libraries(eightdigits_display_plugin PUBLIC libqonvince_shared Qt5::Core)
 
 if(WIN32)
-	install(TARGETS eightdigits_display_plugin RUNTIME DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT extradisplayplugins OPTIONAL)
+	install(TARGETS eightdigits_display_plugin RUNTIME DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT qonvince-displayplugins OPTIONAL)
 else()
-	install(TARGETS eightdigits_display_plugin LIBRARY DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT extradisplayplugins OPTIONAL)
+	install(TARGETS eightdigits_display_plugin LIBRARY DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT qonvince-displayplugins OPTIONAL)
 endif()

--- a/plugins/otpdisplay/integer/sixdigits/CMakeLists.txt
+++ b/plugins/otpdisplay/integer/sixdigits/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(sixdigits_display_plugin PUBLIC ${CMAKE_CURRENT_LIST_
 target_link_libraries(sixdigits_display_plugin PUBLIC libqonvince_shared Qt5::Core)
 
 if(WIN32)
-	install(TARGETS sixdigits_display_plugin RUNTIME DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT extradisplayplugins OPTIONAL)
+	install(TARGETS sixdigits_display_plugin RUNTIME DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT qonvince-displayplugins OPTIONAL)
 else()
-	install(TARGETS sixdigits_display_plugin LIBRARY DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT extradisplayplugins OPTIONAL)
+	install(TARGETS sixdigits_display_plugin LIBRARY DESTINATION usr/share/Equit/Qonvince/plugins/otpdisplay COMPONENT qonvince-displayplugins OPTIONAL)
 endif()

--- a/qonvince/CMakeLists.txt
+++ b/qonvince/CMakeLists.txt
@@ -59,32 +59,36 @@ target_link_libraries(qonvince ${QONVICE_QT_LIBS} ${QCA_LIBRARY} dl libqonvince_
 
 set(QONVINCE_ICON_INSTALL_DIR "usr/share/icons/hicolor")
 
-install(TARGETS qonvince RUNTIME DESTINATION usr/bin COMPONENT application)
+install(TARGETS qonvince RUNTIME DESTINATION usr/bin COMPONENT qonvince)
 install(FILES "../dist/qonvince.desktop" DESTINATION usr/share/applications
 	PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_EXECUTE WORLD_READ
 	CONFIGURATIONS Release
-	COMPONENT application)
-install(FILES "../dist/application_icon.svg" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/scalable/apps/qonvince.svg"
+	COMPONENT qonvince)
+install(FILES "../dist/application_icon.svg" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/scalable/apps"
 	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+	RENAME qonvince.svg
 	CONFIGURATIONS Release
-	COMPONENT application)
-install(FILES "../dist/application_icon_32.png" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/32x32/apps/qonvince.png"
+	COMPONENT qonvince)
+install(FILES "../dist/application_icon_32.png" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/32x32/apps"
 	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+	RENAME qonvince.png
 	CONFIGURATIONS Release
-	COMPONENT application)
-install(FILES "../dist/application_icon_24.png" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/24x24/apps/qonvince.png"
+	COMPONENT qonvince)
+install(FILES "../dist/application_icon_24.png" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/24x24/apps"
 	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+	RENAME qonvince.png
 	CONFIGURATIONS Release
-	COMPONENT application)
-install(FILES "../dist/application_icon.png" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/128x128/apps/qonvince.png"
+	COMPONENT qonvince)
+install(FILES "../dist/application_icon.png" DESTINATION "${QONVINCE_ICON_INSTALL_DIR}/128x128/apps"
 	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
+	RENAME qonvince.png
 	CONFIGURATIONS Release
-	COMPONENT application)
+	COMPONENT qonvince)
 install(FILES "../dist/doc/qonvince/copyright.txt" "../dist/doc/qonvince/changelog" "../dist/doc/qonvince/changelog.Debian" DESTINATION "usr/share/doc/qonvince"
 	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
 	CONFIGURATIONS Release
-	COMPONENT application)
+	COMPONENT qonvince)
 install(FILES "../dist/man/qonvince.1" DESTINATION "usr/share/man/man1"
 	PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
 	CONFIGURATIONS Release
-	COMPONENT application)
+	COMPONENT qonvince)


### PR DESCRIPTION
- fixed application icon install path and name
- renamed application component as 'qonvince'
- fixed name of component for core display plugins
- fixed version and soversion of libqonvince